### PR TITLE
Add token sampling (temperature, top-k, top-p) for GPT-2 generation

### DIFF
--- a/python/cobraml/models/__init__.py
+++ b/python/cobraml/models/__init__.py
@@ -1,5 +1,6 @@
 from .config import ModelConfig, GPT2Config
 from .gpt2 import GPT2LMHeadModel
+from .sampling import sample_next_token
 from .weights import (
     TransposeGPT2Conv1D,
     load_hf_weight,
@@ -17,4 +18,5 @@ __all__ = [
     "DropBuffers",
     "DropGPT2Buffers",
     "AddPrefix",
+    "sample_next_token",
 ]

--- a/python/cobraml/models/sampling.py
+++ b/python/cobraml/models/sampling.py
@@ -1,0 +1,67 @@
+from __future__ import annotations
+
+import torch
+
+
+def _validate_sampling_args(
+    do_sample: bool, temperature: float, top_k: int | None, top_p: float
+) -> None:
+    if not do_sample:
+        return
+
+    if temperature <= 0:
+        raise ValueError("temperature must be > 0 when do_sample=True")
+    if top_k is not None and top_k < 0:
+        raise ValueError("top_k must be >= 0")
+    if not (0 < top_p <= 1):
+        raise ValueError("top_p must be in (0, 1]")
+
+
+def _apply_top_k(logits: torch.Tensor, top_k: int | None) -> torch.Tensor:
+    if top_k is None or top_k == 0:
+        return logits
+
+    k = min(top_k, logits.size(-1))
+    topk_values = torch.topk(logits, k, dim=-1).values
+    threshold = topk_values[..., -1, None]
+    return logits.masked_fill(logits < threshold, float("-inf"))
+
+
+def _apply_top_p(logits: torch.Tensor, top_p: float) -> torch.Tensor:
+    if top_p >= 1.0:
+        return logits
+
+    sorted_logits, sorted_indices = torch.sort(logits, descending=True, dim=-1)
+    sorted_probs = torch.softmax(sorted_logits, dim=-1)
+    cumulative_probs = torch.cumsum(sorted_probs, dim=-1)
+
+    sorted_mask = cumulative_probs > top_p
+    # Keep the first token where cumulative probability crosses top_p.
+    sorted_mask[..., 1:] = sorted_mask[..., :-1].clone()
+    sorted_mask[..., 0] = False
+    sorted_logits = sorted_logits.masked_fill(sorted_mask, float("-inf"))
+
+    filtered_logits = torch.full_like(logits, float("-inf"))
+    return filtered_logits.scatter(-1, sorted_indices, sorted_logits)
+
+
+def sample_next_token(
+    logits: torch.Tensor,
+    *,
+    do_sample: bool = False,
+    temperature: float = 1.0,
+    top_k: int | None = None,
+    top_p: float = 1.0,
+) -> torch.Tensor:
+    """Select next token IDs from logits of shape [B, vocab]."""
+    _validate_sampling_args(do_sample, temperature, top_k, top_p)
+
+    if not do_sample:
+        return torch.argmax(logits, dim=-1, keepdim=True)
+
+    scaled_logits = logits / temperature
+    filtered_logits = _apply_top_k(scaled_logits, top_k)
+    filtered_logits = _apply_top_p(filtered_logits, top_p)
+
+    probs = torch.softmax(filtered_logits, dim=-1)
+    return torch.multinomial(probs, num_samples=1)

--- a/python/tests/models/test_gpt2-xl.py
+++ b/python/tests/models/test_gpt2-xl.py
@@ -44,14 +44,13 @@ def run_us() -> torch.Tensor:
     with torch.inference_mode():
         model.load_state_dict(state_dict, strict=False)
 
-        # generate with our model
-        our_ids = input_ids.clone()
-        for _ in range(max_tokens):
-            logits = model(our_ids)
-            next_token = logits[0, -1].argmax().unsqueeze(0).unsqueeze(0)
-            our_ids = torch.cat([our_ids, next_token], dim=1)
-            if next_token.item() == eos_token_id:
-                break
+        # deterministic path used for parity against HF
+        our_ids = model.generate(
+            input_ids.clone(),
+            max_new_tokens=max_tokens,
+            eos_token_id=eos_token_id,
+            do_sample=False,
+        )
 
     del model, state_dict
     torch.cuda.empty_cache()

--- a/python/tests/models/test_sampling.py
+++ b/python/tests/models/test_sampling.py
@@ -1,0 +1,56 @@
+import torch
+import pytest
+
+from cobraml.models import sample_next_token
+
+
+def test_sample_next_token_greedy_matches_argmax():
+    logits = torch.tensor([[1.0, 3.0, 2.0], [9.0, -1.0, 0.0]])
+    out = sample_next_token(logits, do_sample=False)
+    expected = torch.argmax(logits, dim=-1, keepdim=True)
+    assert out.equal(expected)
+
+
+def test_sample_next_token_top_k_one_is_deterministic():
+    torch.manual_seed(0)
+    logits = torch.tensor([[1.0, 3.0, 2.0]])
+    out = sample_next_token(logits, do_sample=True, top_k=1)
+    assert out.item() == 1
+
+
+def test_sample_next_token_top_p_filters_tail_tokens():
+    torch.manual_seed(0)
+    logits = torch.tensor([[10.0, 1.0, 0.0]])
+    out = sample_next_token(logits, do_sample=True, top_p=0.5)
+    assert out.item() == 0
+
+
+def test_sample_next_token_top_p_keeps_boundary_token():
+    # softmax([2,1,0]) ~= [0.665, 0.245, 0.090]
+    # top_p=0.8 should keep first two tokens (indices 0 and 1).
+    torch.manual_seed(0)
+    logits = torch.tensor([[2.0, 1.0, 0.0]])
+    out = sample_next_token(logits, do_sample=True, top_p=0.8)
+    assert out.item() in {0, 1}
+
+
+@pytest.mark.parametrize(
+    "temperature,top_k,top_p",
+    [
+        (0.0, None, 1.0),
+        (-1.0, None, 1.0),
+        (1.0, -1, 1.0),
+        (1.0, None, 0.0),
+        (1.0, None, 1.5),
+    ],
+)
+def test_sample_next_token_invalid_args(temperature, top_k, top_p):
+    logits = torch.tensor([[1.0, 2.0]])
+    with pytest.raises(ValueError):
+        sample_next_token(
+            logits,
+            do_sample=True,
+            temperature=temperature,
+            top_k=top_k,
+            top_p=top_p,
+        )


### PR DESCRIPTION
## Summary
Fixes #26 by adding non-greedy token selection for generation.

## Acceptance Criteria Mapping
- Temperature sampling: implemented via  scaling in .
- Top-K sampling: implemented via logits filtering with .
- Top-P (nucleus) sampling: implemented via cumulative-probability filtering with boundary-token retention.
- Torch/Triton acceptable for now: implemented in Torch ( + ) as requested.

## Changes
- Added 
  - 
  - input validation for sampling arguments
- Updated 
  - added 
  - supports greedy () and sampling ()
  - EOS-aware early-stop handling for batches
- Updated exports in 
- Updated parity path in 
  - switched custom model generation from manual argmax loop to deterministic 
- Added 
  - greedy matches argmax
  - top-k deterministic behavior for 
  - top-p filtering behavior and boundary-token coverage
  - invalid argument checks

## Notes
- This PR keeps deterministic generation for parity tests while enabling sampling for real inference.
- Sampling currently runs in Torch; CUDA/Triton kernels can be layered on later without API changes.

## Validation
- Listing '/Users/ngovindan/Documents/Work/app/cobraml/CobraMLng'...
Compiling '/Users/ngovindan/Documents/Work/app/cobraml/CobraMLng/setup.py'...
Listing '/Users/ngovindan/anaconda3/lib/python311.zip'...
Can't list '/Users/ngovindan/anaconda3/lib/python311.zip'
Listing '/Users/ngovindan/anaconda3/lib/python3.11'...
Compiling '/Users/ngovindan/anaconda3/lib/python3.11/_sysconfigdata_x86_64_apple_darwin13_4_0.py'...
Listing '/Users/ngovindan/anaconda3/lib/python3.11/lib-dynload'...
Listing '/Users/ngovindan/anaconda3/lib/python3.11/site-packages'...
Compiling '/Users/ngovindan/anaconda3/lib/python3.11/site-packages/pycurl.py'...
Listing '/Users/ngovindan/anaconda3/lib/python3.11/site-packages/aeosa'... on all modified Python files passed.
- Full ============================= test session starts ==============================
platform darwin -- Python 3.11.3, pytest-7.3.1, pluggy-1.0.0
rootdir: /Users/ngovindan/Documents/Work/app/cobraml/CobraMLng
configfile: pyproject.toml
testpaths: python/tests
plugins: anyio-3.5.0, hydra-core-1.3.2
collected 0 items / 3 errors

==================================== ERRORS ====================================
____________ ERROR collecting python/tests/layers/test_attention.py ____________
ImportError while importing test module '/Users/ngovindan/Documents/Work/app/cobraml/CobraMLng/python/tests/layers/test_attention.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../../../anaconda3/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
python/tests/layers/test_attention.py:2: in <module>
    from cobraml.layers import MultiHeadAttention, FusedMultiHeadAttention
E   ModuleNotFoundError: No module named 'cobraml'
_____________ ERROR collecting python/tests/models/test_gpt2-xl.py _____________
ImportError while importing test module '/Users/ngovindan/Documents/Work/app/cobraml/CobraMLng/python/tests/models/test_gpt2-xl.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../../../anaconda3/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
python/tests/models/test_gpt2-xl.py:1: in <module>
    from cobraml.utils import load_hf_config
E   ModuleNotFoundError: No module named 'cobraml'
____________ ERROR collecting python/tests/models/test_sampling.py _____________
ImportError while importing test module '/Users/ngovindan/Documents/Work/app/cobraml/CobraMLng/python/tests/models/test_sampling.py'.
Hint: make sure your test modules/packages have valid Python names.
Traceback:
../../../../../anaconda3/lib/python3.11/importlib/__init__.py:126: in import_module
    return _bootstrap._gcd_import(name[level:], package, level)
python/tests/models/test_sampling.py:4: in <module>
    from cobraml.models import sample_next_token
E   ModuleNotFoundError: No module named 'cobraml'
=========================== short test summary info ============================
ERROR python/tests/layers/test_attention.py
ERROR python/tests/models/test_gpt2-xl.py
ERROR python/tests/models/test_sampling.py
!!!!!!!!!!!!!!!!!!! Interrupted: 3 errors during collection !!!!!!!!!!!!!!!!!!!!
============================== 3 errors in 10.81s ============================== could not be run in this environment due a local torch import/runtime abort.